### PR TITLE
Android security 11.0.0 release 60

### DIFF
--- a/core/version_defaults.mk
+++ b/core/version_defaults.mk
@@ -240,7 +240,7 @@ ifndef PLATFORM_SECURITY_PATCH
     #  It must be of the form "YYYY-MM-DD" on production devices.
     #  It must match one of the Android Security Patch Level strings of the Public Security Bulletins.
     #  If there is no $PLATFORM_SECURITY_PATCH set, keep it empty.
-      PLATFORM_SECURITY_PATCH := 2022-10-05
+      PLATFORM_SECURITY_PATCH := 2022-11-01
 endif
 .KATI_READONLY := PLATFORM_SECURITY_PATCH
 


### PR DESCRIPTION
Android security 11.0.0 release 61

Bump Security String to 2022-11-01, since the November 2022 kernel patches are included only (no previous ones)